### PR TITLE
Use same textdomain.

### DIFF
--- a/better-admin-post-types.php
+++ b/better-admin-post-types.php
@@ -48,7 +48,7 @@ define( 'BAPT_URL', plugins_url( '', __FILE__ ) );
  * Load plugin textdomain.
  */
 function bapt_load_textdomain() {
-	load_plugin_textdomain( 'bapt_plugin', false, basename( dirname( __FILE__ ) ) . '/languages' );
+	load_plugin_textdomain( 'better-admin-post-types', false, basename( dirname( __FILE__ ) ) . '/languages' );
 }
 
 add_action( 'plugins_loaded', 'bapt_load_textdomain' );

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -69,7 +69,7 @@ function bapt_edit_built_in_post_type_args( $args, $post_type ) {
 			if ( 'post' === $post_type ) {
 
 				// set the description string.
-				$post_desc = __( 'Posts are your sites news or blog.', 'hd-basement' );
+				$post_desc = __( 'Posts are your sites news or blog.', 'better-admin-post-types' );
 
 			}
 
@@ -77,7 +77,7 @@ function bapt_edit_built_in_post_type_args( $args, $post_type ) {
 			if ( 'page' === $post_type ) {
 
 				// set the description string.
-				$post_desc = __( 'Pages are good for your sites static content.', 'hd-basement' );
+				$post_desc = __( 'Pages are good for your sites static content.', 'better-admin-post-types' );
 
 			}
 


### PR DESCRIPTION
For future, if you are planning to put this plugin on WordPress.org repo, [text domain should be same as your plugin’s base directory](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain) so that GlotPress (translator tool) recognize strings.

Thank you for sharing wonderful plugin!