### PR TITLE
Add context to admin page registration strings

### DIFF
--- a/inc/admin/admin-menus.php
+++ b/inc/admin/admin-menus.php
@@ -13,8 +13,8 @@ function bapt_admin_menus() {
 
 	// Add the menu for content.
 	add_menu_page(
-		__( 'Content', 'better-admin-post-types' ),
-		__( 'Content', 'better-admin-post-types' ),
+		_x( 'Content', 'page title' 'better-admin-post-types' ),
+		_x( 'Content', 'menu title', 'better-admin-post-types' ),
 		'edit_posts',
 		'bapt_content',
 		'bapt_content_page',


### PR DESCRIPTION
Some languages may require different strings for menu item vs page title, so allow them to be differentiated.